### PR TITLE
[oh-my-zsh] 'current_branch' is deprecated, using 'git_current_branch…

### DIFF
--- a/ansible/roles/common/files/dot_zshrc
+++ b/ansible/roles/common/files/dot_zshrc
@@ -39,7 +39,7 @@ antigen apply
 
 # Time=%{$fg[blue]%}%D{[%I:%M]}%{$reset_color%}
 export PROMPT='%{$fg_bold[green]%}%n@%m %{$fg[blue]%}%#%{$reset_color%} '
-export RPROMPT='%~ %{$fg[green]%}$(current_branch)%{$reset_color%}'
+export RPROMPT='%~ %{$fg[green]%}$(git_current_branch)%{$reset_color%}'
 
 #export PATH=$HOME/.rbenv/bin:$PATH
 #eval "$(rbenv init -)"


### PR DESCRIPTION
…' instead.